### PR TITLE
add zh/ translation for mcp-for-research

### DIFF
--- a/zh/_blog.yml
+++ b/zh/_blog.yml
@@ -1647,6 +1647,13 @@
     - LLM
     - community
 
+- local: mcp-for-research
+  date: Aug 18, 2025
+  tags:
+    - mcp
+    - research
+    - guide
+
 - local: claude-and-mcp
   date: Aug 19, 2025
   tags:

--- a/zh/mcp-for-research.md
+++ b/zh/mcp-for-research.md
@@ -1,0 +1,123 @@
+---
+title: "面向科研的 MCP：如何将 AI 接入研究工具"
+thumbnail: /blog/assets/mcp-for-research/thumbnail.png
+authors:
+- user: dylanebert
+translators:
+- user: HCS9527
+---
+
+# 面向科研的 MCP：如何将 AI 接入研究工具
+
+学术研究经常需要进行**研究发现**：查找论文、代码，以及相关的模型和数据集。这通常意味着要在 [arXiv](https://arxiv.org/)、[GitHub](https://github.com/) 和 [Hugging Face](https://huggingface.co/) 等平台之间切换，再手动串联这些线索。
+
+[Model Context Protocol (MCP)](https://huggingface.co/learn/mcp-course/unit0/introduction) 是一项标准，允许具备智能体能力的模型与外部工具和数据源通信。在科研探索领域，这意味着人工智能可以通过自然语言指令调用各类研究工具，自动完成平台切换与交叉比对工作。
+
+![Research Tracker MCP 实际运行效果](../assets/mcp-for-research/demo.gif)
+
+## 科研探索：三层抽象架构
+
+和软件开发类似，科研探索流程也可以按抽象层次来理解。
+
+### 1. 手动研究
+
+在最底层的抽象层级中，研究人员需要手动检索资料，并人工完成交叉比对工作。
+
+```bash
+# 典型工作流程：
+1. 在 arXiv 上查找论文
+2. 在 GitHub 上检索实现
+3. 在 Hugging Face 上检查模型和数据集
+4. 交叉比对作者和引用信息
+5. 手动整理发现结果
+```
+
+当需要跟进多条研究线索或开展系统性文献综述时，这种人工操作方式就会变得效率低下。跨平台检索、提取元数据以及信息交叉比对这类重复性工作，自然而然推动人们通过编写脚本实现流程自动化。
+
+### 2. 脚本化工具
+
+Python 脚本可以通过处理 Web 请求、解析响应并组织结果，自动化科研探索流程。
+
+```python
+# research_tracker.py
+def gather_research_info(paper_url):
+    paper_data = scrape_arxiv(paper_url)
+    github_repos = search_github(paper_data['title'])
+    hf_models = search_huggingface(paper_data['authors'])
+    return consolidate_results(paper_data, github_repos, hf_models)
+
+# 针对每篇待调研论文运行
+results = gather_research_info("https://arxiv.org/abs/2103.00020")
+```
+
+[Research Tracker](https://huggingface.co/spaces/dylanebert/research-tracker) 这款研究追踪工具依托各类脚本搭建起系统化的科研探索能力。
+
+虽然脚本比人工检索效率更高，但受接口更新、访问频次限制或解析错误等因素影响，脚本往往无法自动采集数据。倘若缺少人工监督，脚本可能会遗漏相关检索结果，或是返回不完整的信息。
+
+### 3. MCP 集成
+
+MCP 让 AI 系统能够通过自然语言访问这些 Python 工具。
+
+```markdown
+# 示例研究指令
+检索过去 6 个月内发表的最新 Transformer 架构论文：
+- 必须提供可用的实现代码
+- 优先关注带有预训练模型的论文
+- 如有性能基准测试结果，也一并纳入
+```
+
+AI 会编排多个工具、补齐信息缺口，并对结果进行推理：
+
+```python
+# AI 工作流程：
+# 1. 使用 research tracker 工具
+# 2. 搜索缺失信息
+# 3. 与其他 MCP 服务器交叉比对
+# 4. 评估结果与研究目标的相关性
+
+user: "查找这篇论文对应的全部相关资料（代码、模型等）：https://huggingface.co/papers/2010.11929"
+ai: # 组合多个工具来收集完整信息
+```
+
+这可以看作是脚本之上新增的一层抽象层级，在这里，所用的“编程语言”就是自然语言。这契合了 [Software 3.0 的类比逻辑](https://youtu.be/LCEmiRjPEtQ?si=J7elM86eW9XCkMFj)：用自然语言描述研究方向，本身就是软件实现。
+
+该方式同样存在和脚本化方案一样的注意事项：
+
+- 效率高于人工研究，但缺少人工引导时很容易出错
+- 最终效果优劣取决于具体的工具实现方案
+- 只有充分理解底层的人工操作与脚本运行机制，才能设计出更完善的实现方案
+
+## 设置与使用
+
+### 快速设置
+
+添加 Research Tracker MCP 最简单的方式，是通过 [Hugging Face 的 MCP 设置页面](https://huggingface.co/settings/mcp)：
+
+1. 访问 [huggingface.co/settings/mcp](https://huggingface.co/settings/mcp)
+2. 在可用工具列表中搜索「research-tracker-mcp」
+3. 点击，将其添加到工具库
+4. 按照页面提供的说明，为具体客户端完成设置（Claude Desktop、Cursor、Claude Code、VS Code 等）
+
+该工作流程依托 Hugging Face MCP 服务器实现，这也是将 Hugging Face 应用空间作为 MCP 工具使用的标准方式。设置页面会自动生成适配不同客户端的配置文件，且配置内容会保持实时更新。
+
+<script
+	type="module"
+	src="https://gradio.s3-us-west-2.amazonaws.com/4.36.1/gradio.js"
+></script>
+
+<gradio-app theme_mode="light" space="dylanebert/research-tracker-mcp"></gradio-app>
+
+## 了解更多
+
+**开始使用：**
+- [Hugging Face MCP Course](https://huggingface.co/learn/mcp-course/en/unit1/introduction) - 从基础知识到构建自定义工具的完整指南
+- [MCP Official Documentation](https://modelcontextprotocol.io) - 协议规范和架构
+
+**构建自己的工具：**
+- [Gradio MCP Guide](https://www.gradio.app/guides/building-mcp-server-with-gradio) - 将 Python 函数转换为 MCP 工具
+- [Building the Hugging Face MCP Server](https://huggingface.co/blog/building-hf-mcp) - 生产级实现案例研究
+
+**社区：**
+- [Hugging Face Discord](https://hf.co/join/discord) - MCP 开发讨论
+
+准备好实现科研探索流程自动化了吗？不妨试试 [Research Tracker MCP](https://huggingface.co/settings/mcp)，或者利用上述资源自主开发专属科研工具。


### PR DESCRIPTION
## Summary

This PR adds the Chinese translation for the Hugging Face Blog article "MCP for Research: How to Connect AI to Research Tools".

## Changes

- Added `zh/mcp-for-research.md`
- Added the corresponding `mcp-for-research` entry to `zh/_blog.yml`
- Preserved the original authors, thumbnail path, links, image/video references, and inline code
- Added translator metadata: `HCS9527`

## Validation

- `npx -y deno run --allow-net --allow-read ./validate-yaml.ts`
- `npx -y deno run --allow-read ./validate-blog-entries.ts ../zh/mcp-for-research.md`
- Manual checks for frontmatter, code fence count, changed files, and author/committer identity